### PR TITLE
Add qwik-transition to libraries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Inspired by the _awesome-*_ trend on GitHub.
 - [Qwik i18n](https://github.com/mhevery/qwik-i18n.git) - Qwik Official Translation Library to do localization.
 - [Qwik Urql](https://github.com/DustinJSilk/qwik-urql) - A small library to use Urql with Qwik.
 - [Lucide for Qwik](https://github.com/egmaleta/lucide-qwik) - Lucide icon library package (Feather icons fork) for Qwik applications.
+- [Qwik Transition](https://github.com/voluntadpear/qwik-transition) - Light-weight custom Qwik hook for adding smooth CSS transitions to your Qwik components.
 
 ## Starters
 


### PR DESCRIPTION
This PR adds my `qwik-transition` custom hook for CSS transitions to the libraries section.