### PR TITLE
Add qwik-router to the libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Inspired by the _awesome-*_ trend on GitHub.
 - [Qwik Transition](https://github.com/voluntadpear/qwik-transition) - Light-weight custom Qwik hook for adding smooth CSS transitions to your Qwik components.
 - [Qwik Icons](https://github.com/qwikest/icons) - Include popular icons easily in your Qwik projects with @qwikest/icons.
 - [Qwik UI](https://github.com/qwikifiers/qwik-ui) - Components library for Qwik.
+- [Qwik Router](https://github.com/dannyfranca/qwik-router) - Qwik Dynamic SPA-like router for Qwik, inspired by `vue-router` and `react-router`.
 
 ## Starters
 


### PR DESCRIPTION
I've recently published a component called `qwik-router` after the previous developer removed it from npm.

The component I published has been used in production, and I've seen value in sharing it with the world.

I'll keep maintaining it unless the Qwik team creates a dynamic router like the Vue team decided to do.